### PR TITLE
Fix usage of includes in node 4.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
-node_js:
-- "6.0"
 language: node_js
+node_js:
+  - 6
+  - 4
+before_install:
+  - npm install -g npm

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-
 import csrf from 'csrf';
 
 export default class CSRF {
@@ -51,7 +50,7 @@ export default class CSRF {
 
     ctx.response.__defineGetter__('csrf', () => ctx.csrf);
 
-    if (this.opts.excludedMethods.includes(ctx.method))
+    if (this.opts.excludedMethods.indexOf(ctx.method) !== -1)
       return next();
 
     if (!ctx.session.secret)


### PR DESCRIPTION
This PR is to use the method indexOf instead of includes for the reason that it doesn't work with the node 4.6.0 yet and causes error in server after the update.

```
[2016-09-29 23:12:10.592] [INFO] console -   xxx GET / 500 13ms -
  error TypeError: _this.opts.excludedMethods.includes is not a function
    at CSRF.middleware (/Users/hungphan/Desktop/workarea/koa-react-isomorphic/node_modules/koa-csrf/lib/index.js:39:36)
```