### PR TITLE
Remove `auto-bind` dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     }
   ],
   "dependencies": {
-    "auto-bind": "^2.0.0",
     "csrf": "^3.0.6"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 const csrf = require('csrf');
-const autoBind = require('auto-bind');
 
 class CSRF {
   constructor(opts = {}) {
@@ -15,9 +14,7 @@ class CSRF {
 
     this.tokens = csrf(opts);
 
-    autoBind(this);
-
-    return this.middleware;
+    return this.middleware.bind(this);
   }
 
   middleware(ctx, next) {

--- a/test/test.js
+++ b/test/test.js
@@ -24,6 +24,7 @@ test.before.cb(t => {
       ctx.body = ctx.csrf;
       return;
     }
+
     ctx.body = 'OK';
   });
   request = supertest.agent(app.listen(t.end));


### PR DESCRIPTION
The `auto-bind` package depends on `@types/react`. If a TypeScript project is using JSX without using react, the `@types/react` package can cause problems, as it defines a global `JSX` namespace that may conflict with alternative JSX typings from non-react packages.

Users of this package may or may not be using react, so it seems like this package shouldn't rely on something react-specific. `auto-bind` is only used for binding `this.middleware`, so it's a fairly simple change to remove it.

Let me know if this sounds reasonable or if you have any questions/concerns.