### PR TITLE
Exclude path

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ yarn add koa-csrf
 * `invalidTokenStatusCode` (Number) - defaults to `403`
 * `excludedMethods` (Array) - defaults to `[ 'GET', 'HEAD', 'OPTIONS' ]`
 * `disableQuery` (Boolean) - defaults to `false`
-
+* `excludePath` (Array) - defaults to none. Excludes listed paths from CSRF check.
 
 ## Open Source Contributor Requests
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,8 @@ class CSRF {
         invalidTokenMessage: 'Invalid CSRF token',
         invalidTokenStatusCode: 403,
         excludedMethods: ['GET', 'HEAD', 'OPTIONS'],
-        disableQuery: false
+        disableQuery: false,
+        excludePath:[]
       },
       opts
     );
@@ -39,6 +40,10 @@ class CSRF {
     ctx.response.__defineGetter__('csrf', () => ctx.csrf);
 
     if (this.opts.excludedMethods.indexOf(ctx.method) !== -1) {
+      return next();
+    }
+
+    if ( this.opts.excludePath.findIndex(path => path === ctx.path) >= 0) {
       return next();
     }
 


### PR DESCRIPTION
This ensure some requests like external server POST callback can work without requiring CSRF check.
